### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ parameter: -jar ../IntegrityExcelTestSession.jar
 
 Option 2: In a shared folder
 - Take all files from "dist" folder and place them somewhere centrally
+- Copy the files "mksapi.jar" and "mksclient.jar" from your IntegrityClient/lib folder into the lib folder you placed somewhere centrally, replace if nescessary
 - Register a custom menu as described before, but with the following change
 ```
 parameter: -jar <your shared folder>/IntegrityExcelTestSession.jar


### PR DESCRIPTION
I added one line in the "Option 2: In a shared folder" installation guide to counter the following issue:

The "Integrity Excel Test Session" window does not open and no error (only a successful connection) is logged when using the "Option 2: In a shared folder" installation.

From the MANIFEST file in the IntegrityExcelTestSession.jar it becomes clear that "mksclient.jar" is also a needed library, but it is not included in the dist/lib folder. For this reason a workaround is to copy the "mksclient.jar" file from the Integrity installation to the dist/lib folder. For the sake of completeness I also replaced the "mksapi.jar" in the dist/lib folder with the one from the Integrity installation. This was tested under Integrity 11.1 and I do not know if it applies to other versions as well.